### PR TITLE
#161858009 Route to cancel a parcel order with an id

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -12,24 +12,37 @@ const parcelControler = {
 
   createNew(req, res) {
     if (!req.body.destination || !req.body.location || !req.body.unit_weight) {
-      res.status(400).send({ message: 'All fields are required' });
+      res.status(400).send({ message: 'All fields are Required' });
     } else {
       senditModel.create(req.body);
-      res.status(201).send({ message: 'New order created' });
+      res.status(201).send({ message: 'New Parcel order Created' });
     }
   },
 
   getOne(req, res) {
-    const getone = senditModel.findOne(req.params.id);
+    const getone = senditModel.findOne(req.params.parcelid);
     if (getone === undefined) {
       res.status(400).send({
         status: 'Failed',
-        message: 'id not found',
+        message: 'Parcel Order id not found',
       });
     } else {
       res.status(200).send({
         status: 'Success',
-        message: `${getone}`,
+        message: getone,
+      });
+    }
+  },
+
+  delete(req, res) {
+    const del = senditModel.delete(req.params.parcelid);
+    if (del === false) {
+      res.status(400).send({
+        message: 'Parcel Order id not found'
+      });
+    } else {
+      res.status(200).send({
+        message: 'Parcel Order deleted'
       });
     }
   },

--- a/src/model/parcelModel.js
+++ b/src/model/parcelModel.js
@@ -1,5 +1,3 @@
-const momentDate = moment().format('MMMM Do YYYY, h:mm:ss a');
-
 
 class Sendit {
   constructor() {
@@ -9,7 +7,7 @@ class Sendit {
   create(data) {
     const newParcel = {
       parcel_id: data.parcel_id || '',
-      user: data.user || '',
+      userid: data.userid || '',
       location: data.location || '',
       destination: data.destination || '',
       unit_weight: data.unit_weight || '',
@@ -29,8 +27,18 @@ class Sendit {
      return this.ds;
    }
 
-  findOne(id) {
-    return this.ds.find((todo, index) => todo.parcel_id === id);
+  findOne(parcelid) {
+    return this.ds.find((todo, index) => todo.parcel_id === parcelid);
+  }
+
+  delete(parcelid) {
+    const del = this.findOne(parcelid);
+    if (del === undefined) {
+      return false;
+    }
+    const index = this.ds.indexOf(del);
+    this.ds.splice(index);
+    return true;
   }
 
   

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -13,8 +13,13 @@ const parcelRoute = (app) => {
   );
 
   app.get(
-    '/api/v1/parcels/:id',
+    '/api/v1/parcels/:parcelid',
     parcelControler.getOne,
+  );
+
+  app.put(
+    '/api/v1/parcels/:parcelid/cancel',
+    parcelControler.delete,
   );
 };
 


### PR DESCRIPTION
#### What does this PR do?
- This PR integrates an Api route to cancel a parcel order by id
#### Description of Task to be completed?
- When a PUT request is sent to localhost:3000/api/v1/parcels/:parcelid/cancel, the parcel order is canceled
- A user's request can only be completed when all the required data are sent
- A successful request should return a status of 200
#### How should this be manually tested?
- Pull this branch [ft-user-able-cancel-parcel-order-161858009](https://github.com/openwell/sendIT/tree/ft-user-able-cancel-parcel-order-161858009) off this repository
- On your command line, run npm install to install all dependencies for this app
- On your command line, run node src/index.js  to start the app
- App would run on port 3000
- Access the endpoint with a POST request on localhost:3000/api/parcels/:parcelid/cancel
#### Any background context you want to provide?
- This app is a node app and would require nodejs and npm installation on your local machine
#### What are the relevant pivotal tracker stories?
[161858009](https://www.pivotaltracker.com/story/show/161858009)
#### Screenshots (if appropriate)
None
#### Questions:
None